### PR TITLE
NPE fix. Caused by AsyncStorage.delItem(...) call

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Getting an item from the cache also moves it to the end of the LRU list: it will
 ### Delete an item from the cache
 
 ```javascript
-cache.delItem('key1', function(err) {
+cache.removeItem('key1', function(err) {
     // 'key1' is no more.
 });
 ```

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -71,7 +71,7 @@ Cache.prototype.enforceLimits = function(callback) {
         var victimCount = Math.max(0, lru.length - self.policy.maxEntries);
         var victimList = lru.slice(0, victimCount);
         async.eachSeries(victimList, function(key, callback) {
-            self.delItem(key, callback);
+            self.removeItem(key, callback);
         }, function(err) {
             var survivorList = lru.slice(victimCount);
             self.setLRU(survivorList, callback);
@@ -79,10 +79,10 @@ Cache.prototype.enforceLimits = function(callback) {
     });
 };
 
-Cache.prototype.delItem = function(key, callback) {
+Cache.prototype.removeItem = function(key, callback) {
     var self = this;
     var compositeKey = this.makeCompositeKey(key);
-    this.backend.delItem(compositeKey, function(err) {
+    this.backend.removeItem(compositeKey, function(err) {
         if (err) return callback(err);
 
         self.removeFromLRU(key, callback);

--- a/lib/memoryStore.js
+++ b/lib/memoryStore.js
@@ -11,7 +11,7 @@ MemoryStore.setItem = function(key, value, callback) {
     return callback();
 };
 
-MemoryStore.delItem = function(key, callback) {
+MemoryStore.removeItem = function(key, callback) {
     delete store[key];
     return callback();
 };

--- a/test/units/cache.js
+++ b/test/units/cache.js
@@ -26,7 +26,7 @@ describe('cache', function() {
     it('can delete entry', function(done) {
         cache.setItem('key1', 'value1', function(err) {
             assert(!err);
-            cache.delItem('key1', function(err) {
+            cache.removeItem('key1', function(err) {
                 assert(!err);
                 cache.getItem('key1', function(err, value) {
                     assert(!err);


### PR DESCRIPTION
NPE caused by AsyncStorage.delItem(...) call, because AsyncStorage has only removeItem(...) function.