### PR TITLE
Remove Cache::getItem duplicate defintion

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -93,16 +93,6 @@ Cache.prototype.getItem = function(key, callback) {
     var self = this;
 
     this.peekItem(key, function(err, value) {
-        callback(err, value);
-
-        self.refreshLRU(key, function() {});
-    });
-};
-
-Cache.prototype.getItem = function(key, callback) {
-    var self = this;
-
-    this.peekItem(key, function(err, value) {
         if (err) return callback(err);
         if (!value) return callback();
 


### PR DESCRIPTION
Issue https://github.com/timfpark/react-native-cache/issues/7