### PR TITLE
Fix bug when key had a colon in it, add test

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -50,14 +50,21 @@ describe("cache", () => {
         expect(value).toBe("value1");
     });
 
+    it("can set and get entry with colon in key", async () => {
+        await cache.set("key2:key2", "value2");
+        const value = await cache.get("key2:key2");
+
+        expect(value).toBe("value2");
+    });
+
     it("can get all elements", async () => {
         const entries = await cache.getAll();
 
         expect(entries).not.toBeUndefined();
         expect(Object.keys(entries).length).toBe(1);
 
-        const key1Entry: any = entries["key1"];
-        expect(key1Entry["value"]).toBe("value1");
+        const key2Entry = entries["key2:key2"];
+        expect(key2Entry["value"]).toBe("value2");
     });
 
     it("can clear all elements", async () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -58,21 +58,15 @@ export default class Cache {
         });
 
         const results = await this.backend.multiGet(namespaceKeys);
-        const allEntries: { [key: string]: string } = {};
-        for (const result of results) {
-            const keyComponents = result[0].split(":");
-
-            if (keyComponents.length !== 2) {
-                continue;
-            }
-
-            const key: string = keyComponents[1];
+        const allEntries: { [key: string]: any } = {};
+        for (const [compositeKey, value] of results) {
+            const key = this.fromCompositeKey(compositeKey);
 
             if (key === "_lru") {
                 continue;
             }
 
-            allEntries[key] = JSON.parse(result[1]);
+            allEntries[key] = JSON.parse(value);
         }
 
         return allEntries;
@@ -155,6 +149,10 @@ export default class Cache {
 
     protected makeCompositeKey(key: string) {
         return `${this.namespace}:${key}`;
+    }
+
+    protected fromCompositeKey(compositeKey: string) {
+        return compositeKey.slice(this.namespace.length + 1);
     }
 
     protected async refreshLRU(key: string) {


### PR DESCRIPTION
Thanks for making this, it's clean and easy to read code :)

The old code had `.split(":")` which could split multiple times. If there was more than two components the the key was skipped.
Added `fromCompositeKey` function to fix the bug

A different way to fix this would be to change `.split(":")` to `.split(":", 2)`, but I think it's cleaner to slice off the namespace - up to you?