### PR TITLE
fix: make maxEntries optional in cache policy

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,7 +6,7 @@ export interface ICacheOptions {
 }
 
 export interface ICachePolicy {
-    maxEntries: number;
+    maxEntries?: number;
     stdTTL: number; // second
 }
 


### PR DESCRIPTION
This pull request addresses the following issue:

The documentation states that the maxEntries field in the cache policy interface is optional, but in the TypeScript implementation, it is mandatory.